### PR TITLE
HC-3990 Fix CORS in Error Response

### DIFF
--- a/src/Response/ErrorResponse.php
+++ b/src/Response/ErrorResponse.php
@@ -6,6 +6,10 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 
 class ErrorResponse extends JsonResponse
 {
+    const DEFAULT_ERROR_HEADERS = [
+        'Access-Control-Allow-Origin' => '*'
+    ];
+
     public function __construct($message, string $innerErrorCode = null, int $status = self::HTTP_BAD_REQUEST, $errors = [])
     {
         $responseData = [
@@ -19,6 +23,6 @@ class ErrorResponse extends JsonResponse
             $responseData['errors'] = $errors;
         }
 
-        parent::__construct($responseData, $status);
+        parent::__construct($responseData, $status, self::DEFAULT_ERROR_HEADERS);
     }
 }


### PR DESCRIPTION
Симфа не наполняет CORSами ответы, если они отдаются вне пределов Kernel::handle.
Из-за этого фронт не может понять код ошибки.
https://helpcrunch.atlassian.net/browse/HC-3990