### PR TITLE
CdnHelper hotfix: fix url options format

### DIFF
--- a/src/Helper/CdnHelper.php
+++ b/src/Helper/CdnHelper.php
@@ -33,14 +33,15 @@ class CdnHelper
 
     public static function getOptionsUrl(array $options): string
     {
-        $urlParts = ['-'];
+        $urlParts = [];
         foreach ($options as $optionKey => $optionValue) {
+            $urlParts[] = '-';
             $urlParts[] = $optionKey;
             $urlParts[] = $optionValue;
         }
 
         $url = '';
-        if (count($urlParts) > 1) {
+        if (count($urlParts)) {
             $url = implode('/', $urlParts) . '/';
         }
 


### PR DESCRIPTION
У uploadcare изменился формат передачи параметров в их урлах. Теперь перед каждым накладываемым фильтром необходимо добавлять /-/.

Ссылка для примера:
https://ucarecdn.com/99db37f0-162f-42cd-ac4f-8cf931b2e713/-/scale_crop/40x40/-/format/png/